### PR TITLE
Remove the right margin on the last item in a navbar-right

### DIFF
--- a/public/css/master.css
+++ b/public/css/master.css
@@ -20,6 +20,10 @@ a {
   color: #f5fffa;
 }
 
+.navbar-nav.navbar-right:last-child {
+  margin-right: 0;
+}
+
 .active {
   background-color: #f9fff9;
   color: #333;


### PR DESCRIPTION
By default, `.navbar-right` has `margin-right: -15px` applied. This PR removes that on the final right navbar.